### PR TITLE
0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change logs
+## 0.1.4
+Minor update.
+* Adjust the type of data from float64 to float in pkc.py to raise the 'ZeroDivisionError: float division by zero'.
+
 ## 0.1.3
 Minor update.
 * Fix bug.

--- a/pk4adi/__init__.py
+++ b/pk4adi/__init__.py
@@ -10,4 +10,4 @@ from .pk import *
 from .pkc import *
 from .utils import *
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'

--- a/pk4adi/pkc.py
+++ b/pk4adi/pkc.py
@@ -85,7 +85,7 @@ def compare_pks(pk1, pk2, auto_print = True):
     DF = n_case - 1
     PKDJ = n_case * PKD - DF / n_case * SumD
     SEDJ = math.sqrt( DF / n_case * ( SSD - 1 / n_case * SumD * SumD ))
-    TD = PKDJ / SEDJ
+    TD = float(PKDJ) / float(SEDJ)
     TP, TJ = T2P(TD, DF)
 
     # save the variables.


### PR DESCRIPTION
Adjust the type of data from float64 to float in pkc.py to raise the 'ZeroDivisionError: float division by zero'.